### PR TITLE
Integrate background image asset

### DIFF
--- a/lib/game.dart
+++ b/lib/game.dart
@@ -74,6 +74,12 @@ class _BalloonPopPageState extends State<BalloonPopPage> {
       backgroundColor: Colors.lightBlue[50],
       body: Stack(
         children: [
+          Positioned.fill(
+            child: Image.asset(
+              'assets/background.png',
+              fit: BoxFit.cover,
+            ),
+          ),
           ...balloons,
           Positioned(
             top: 50,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,3 +19,4 @@ flutter:
   assets:
     - assets/balloon.png
     - assets/pop.mp3
+    - assets/background.png


### PR DESCRIPTION
## Summary
- register new `background.png` asset
- display the background image behind balloons

## Testing
- `dart format lib/game.dart pubspec.yaml` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417d4193c4832b9f7be6ea569e6205