### PR TITLE
Add explosion effect to balloons

### DIFF
--- a/lib/balloon.dart
+++ b/lib/balloon.dart
@@ -18,6 +18,7 @@ class _BalloonState extends State<Balloon> with SingleTickerProviderStateMixin {
   late AnimationController _controller;
   late Animation<double> _animation;
   double? yStart;
+  bool _popped = false;
 
   @override
   void initState() {
@@ -35,7 +36,7 @@ class _BalloonState extends State<Balloon> with SingleTickerProviderStateMixin {
           if (mounted) setState(() {});
         })
         ..addStatusListener((status) {
-          if (status == AnimationStatus.completed) {
+          if (status == AnimationStatus.completed && !_popped) {
             widget.onPopped(widget);
           }
         });
@@ -51,7 +52,16 @@ class _BalloonState extends State<Balloon> with SingleTickerProviderStateMixin {
   }
 
   void _pop() {
-    widget.onPopped(widget);
+    if (_popped) return;
+    setState(() {
+      _popped = true;
+    });
+    _controller.stop();
+    Future.delayed(Duration(milliseconds: 300), () {
+      if (mounted) {
+        widget.onPopped(widget);
+      }
+    });
   }
 
   @override
@@ -64,7 +74,10 @@ class _BalloonState extends State<Balloon> with SingleTickerProviderStateMixin {
       top: _animation.value,
       child: GestureDetector(
         onTap: _pop,
-        child: Image.asset('assets/balloon.png', width: 240),
+        child: Image.asset(
+          _popped ? 'assets/balloon_explode.png' : 'assets/balloon.png',
+          width: 240,
+        ),
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,3 +20,4 @@ flutter:
     - assets/balloon.png
     - assets/pop.mp3
     - assets/background.png
+    - assets/balloon_explode.png


### PR DESCRIPTION
## Summary
- add placeholder `balloon_explode.png` asset
- make balloons show explosion image when tapped
- register new asset in `pubspec.yaml`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417f257ed0832b8ea12380f9e9bed3